### PR TITLE
Relax committee filtering in committees.html template

### DIFF
--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -205,7 +205,7 @@ class CommitteesView(ListView):
     context_object_name = 'committees'
 
     def get_queryset(self):
-        return Organization.committees().filter(name__startswith='Committee')
+        return Organization.committees().filter(name__contains='Committee')
 
 class CommitteeDetailView(DetailView):
     model = Organization

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -205,7 +205,7 @@ class CommitteesView(ListView):
     context_object_name = 'committees'
 
     def get_queryset(self):
-        return Organization.committees().filter(name__contains='Committee')
+        return Organization.committees.all()
 
 class CommitteeDetailView(DetailView):
     model = Organization
@@ -216,7 +216,7 @@ class CommitteeDetailView(DetailView):
         context = super(CommitteeDetailView, self).get_context_data(**kwargs)
         
         committee = context['committee']
-        context['memberships'] = committee.memberships.filter(role='Committee Member')
+        context['memberships'] = committee.memberships.all()
         
         if getattr(settings, 'COMMITTEE_DESCRIPTIONS', None):
             description = settings.COMMITTEE_DESCRIPTIONS.get(committee.slug)


### PR DESCRIPTION
When forking Chicago councilmatic, no committees were showing up.

The one downside is that organizations with names like "Sub-Committee" (capitalized similarly) will now also show up. You guys would know whether this might disrupt other councilmatic sites.

Anyhow, there must be a better filter, right? Perhaps children of the main council? Or orgs of type "committee"?