### PR TITLE
Raise helpful error when org OCD ID doesn't exist

### DIFF
--- a/councilmatic_core/management/commands/loaddata.py
+++ b/councilmatic_core/management/commands/loaddata.py
@@ -134,6 +134,9 @@ class Command(BaseCommand):
         r = requests.get(url)
         page_json = json.loads(r.text)
 
+        if page_json.get('error'):
+            raise DataError(page_json['error'])
+
         source_url = ''
         if page_json['sources']:
             source_url = page_json['sources'][0]['url']


### PR DESCRIPTION
Related to https://github.com/datamade/django-councilmatic/issues/44

Was getting error during org lookup where helpful details weren't raised.

If this looks OK, happy to modify PR to raise errors like this for all API calls in loaddata.