### PR TITLE
Gather local person images during `collectstatic` rather than `loaddata`

### DIFF
--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -93,11 +93,15 @@ class Person(models.Model):
         return True if self.memberships.filter(role='Speaker').first() else False   
 
     @property
+    def default_headshot_path(self):
+        return settings.DEFAULT_HEADSHOT_PATH(self) if hasattr(settings, 'DEFAULT_HEADSHOT_PATH') else None
+
+    @property
     def headshot_url(self):
-        if MANUAL_HEADSHOTS is True:
-            return '/static/images/manual-headshots/' + self.slug + '.jpg'
-        elif self.slug in MANUAL_HEADSHOTS:
+        if self.slug in MANUAL_HEADSHOTS:
             return '/static/images/' + MANUAL_HEADSHOTS[self.slug]['image']
+        elif self.default_headshot_path:
+            return self.default_headshot_path
         elif self.headshot:
             return '/static/images/' + self.ocd_id + ".jpg"
         else:

--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -94,7 +94,9 @@ class Person(models.Model):
 
     @property
     def headshot_url(self):
-        if self.slug in MANUAL_HEADSHOTS:
+        if MANUAL_HEADSHOTS is True:
+            return '/static/images/manual-headshots/' + self.slug + '.jpg'
+        elif self.slug in MANUAL_HEADSHOTS:
             return '/static/images/' + MANUAL_HEADSHOTS[self.slug]['image']
         elif self.headshot:
             return '/static/images/' + self.ocd_id + ".jpg"

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -207,7 +207,7 @@ class CommitteesView(ListView):
     context_object_name = 'committees'
 
     def get_queryset(self):
-        return Organization.committees.all()
+        return Organization.committees
 
 class CommitteeDetailView(DetailView):
     model = Organization


### PR DESCRIPTION
Toronto just pulls profiles directly from city site, so defaulting the source
to the city clerk is fine. Would be great if we didn't need to manually manage
a dict with all the paths.

Also, this is particularly pertinent as the
ocd-person/uuid.jpg approach doesn't work on Canadian scrapers where the person
ids changes constantly. (ie. no way to store these static files in version
control under the uuid.)