### PR TITLE
Use static path for saving local councillor headshot

### DIFF
--- a/councilmatic_core/management/commands/loaddata.py
+++ b/councilmatic_core/management/commands/loaddata.py
@@ -22,7 +22,7 @@ import psycopg2
 
 for configuration in ['OCD_JURISDICTION_ID', 
                       'OCD_CITY_COUNCIL_ID', 
-                      'HEADSHOT_PATH',
+                      'HEADSHOT_RELPATH',
                       'LEGISLATIVE_SESSIONS'
                       ]:
 

--- a/councilmatic_core/management/commands/loaddata.py
+++ b/councilmatic_core/management/commands/loaddata.py
@@ -612,7 +612,8 @@ class Command(BaseCommand):
             if page_json['image']:
                 r = requests.get(page_json['image'], verify=False)
                 if r.status_code == 200:
-                    with open((settings.HEADSHOT_PATH + slugify(page_json['name']) + ".jpg"), 'wb') as f:
+                    img_path = os.path.join(settings.BASE_DIR, settings.APP_NAME, 'static', settings.HEADSHOT_RELPATH)
+                    with open(os.path.join(img_path, slugify(page_json['name']) + ".jpg"), 'wb') as f:
                         for chunk in r.iter_content(1000):
                             f.write(chunk)
                             f.flush()

--- a/councilmatic_core/management/commands/loaddata.py
+++ b/councilmatic_core/management/commands/loaddata.py
@@ -612,7 +612,7 @@ class Command(BaseCommand):
             if page_json['image']:
                 r = requests.get(page_json['image'], verify=False)
                 if r.status_code == 200:
-                    with open((settings.HEADSHOT_PATH + page_json['id'] + ".jpg"), 'wb') as f:
+                    with open((settings.HEADSHOT_PATH + slugify(page_json['name']) + ".jpg"), 'wb') as f:
                         for chunk in r.iter_content(1000):
                             f.write(chunk)
                             f.flush()

--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -97,7 +97,7 @@ class Person(models.Model):
         if self.slug in MANUAL_HEADSHOTS:
             return '/static/images/' + MANUAL_HEADSHOTS[self.slug]['image']
         elif self.headshot:
-            return '/static/images/' + self.slug + ".jpg"
+            return '/static/' + settings.HEADSHOT_RELPATH + '/' + self.slug + ".jpg"
         else:
             return '/static/images/headshot_placeholder.png'
 

--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -97,7 +97,7 @@ class Person(models.Model):
         if self.slug in MANUAL_HEADSHOTS:
             return '/static/images/' + MANUAL_HEADSHOTS[self.slug]['image']
         elif self.headshot:
-            return '/static/images/' + self.ocd_id + ".jpg"
+            return '/static/images/' + self.slug + ".jpg"
         else:
             return '/static/images/headshot_placeholder.png'
 


### PR DESCRIPTION
Partial solution for https://github.com/datamade/django-councilmatic/pull/48, that at least makes the paths static between database resets

Ready for review. Minimal change that shouldn't break any existing instances (HEADSHOT_PATH and model's headshot_url prop could be DRY'd out, but that was already an issue, and this is no worse)