### PR TITLE
Use 'date' col for primary sort of bill actions

### DIFF
--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -191,7 +191,7 @@ class BillDetailView(DetailView):
     def get_context_data(self, **kwargs):
         context = super(BillDetailView, self).get_context_data(**kwargs)
         
-        context['actions'] = self.get_object().actions.all().order_by('-order')
+        context['actions'] = self.get_object().actions.all().order_by('-date', '-order')
         bill = context['legislation']
 
         seo = {}


### PR DESCRIPTION
Right now, we're sorting by `order` col only. By default, the order col reflects the scrape order. It seems that this is predictable with legistar sites, but is a little more difficult to get right on Toronto custom-built TMMIS site, since we'll be inferred quite a few bill actions after the fact.

Would be great if we could date sort first :)

cc: @fgregg