### PR TITLE
Hit the canonical API urls (not redirects) when running loaddata

### DIFF
--- a/councilmatic_core/management/commands/loaddata.py
+++ b/councilmatic_core/management/commands/loaddata.py
@@ -135,7 +135,7 @@ class Command(BaseCommand):
 
     def grab_organization_posts(self, organization_ocd_id, parent=None):
 
-        url = base_url+'/'+organization_ocd_id
+        url = base_url+'/'+organization_ocd_id+'/'
         r = requests.get(url)
         page_json = json.loads(r.text)
 
@@ -252,7 +252,7 @@ class Command(BaseCommand):
         # grab people associated with all existing organizations
         orgs = Organization.objects.exclude(name='Democratic').exclude(name='Republican').all()
         for organization in orgs:
-            url = base_url+'/'+organization.ocd_id
+            url = base_url+'/'+organization.ocd_id+'/'
             r = requests.get(url)
             page_json = json.loads(r.text)
 
@@ -311,7 +311,7 @@ class Command(BaseCommand):
 
             for result in result_page.json()['results']:
                 
-                bill_url = '{base}/{bill_id}'.format(base=base_url, bill_id=result['id'])
+                bill_url = '{base}/{bill_id}/'.format(base=base_url, bill_id=result['id'])
                 bill_detail = requests.get(bill_url)
                 
                 leg_session_id = bill_detail.json()['legislative_session']['identifier']
@@ -330,7 +330,7 @@ class Command(BaseCommand):
         if hasattr(settings, 'LEGISLATIVE_SESSIONS') and settings.LEGISLATIVE_SESSIONS:
             session_ids = settings.LEGISLATIVE_SESSIONS
         else:
-            url = base_url+'/'+settings.OCD_JURISDICTION_ID
+            url = base_url+'/'+settings.OCD_JURISDICTION_ID+'/'
             r = requests.get(url)
             page_json = json.loads(r.text)
             session_ids = [session['identifier'] for session in page_json['legislative_sessions']]
@@ -612,7 +612,7 @@ class Command(BaseCommand):
     def grab_person_memberships(self, person_id):
         # this grabs a person and all their memberships
 
-        url = base_url+'/'+person_id
+        url = base_url+'/'+person_id+'/'
         r = requests.get(url)
         page_json = json.loads(r.text)
 
@@ -734,7 +734,7 @@ class Command(BaseCommand):
 
     def grab_event(self, event_ocd_id):
 
-        event_url = base_url+'/'+event_ocd_id
+        event_url = base_url+'/'+event_ocd_id+'/'
         r = requests.get(event_url)
 
 


### PR DESCRIPTION
Currently, we hit the OCD API urls without a trailing slash, for which an error
is thrown on the API backend as django redirects to the slashed url. This
creates a bunch of misleading noise in the logs.

```
2:10:49 PM web.1 |  WARNING Not Found: /ocd-bill/e91f4ef5-e8ca-46f2-901c-97ecc35a1931
2:10:49 PM web.1 |  WARNING Not Found: /ocd-bill/a1f7e698-c812-46ff-950c-b36bdfaee7c1
2:10:49 PM web.1 |  WARNING Not Found: /ocd-bill/f6c3aa0b-fd2a-46d1-9663-14bf3e15d5a5
2:10:49 PM web.1 |  WARNING Not Found: /ocd-bill/5a2b0f9a-2c3a-4d41-8cd9-aba2e34b7d90
2:10:50 PM web.1 |  WARNING Not Found: /ocd-bill/703630e2-d050-4048-9b8b-b71ee3d33d42
2:10:50 PM web.1 |  WARNING Not Found: /ocd-bill/3da76c6b-09c5-4a03-9dd3-23a26d8739e4
2:10:50 PM web.1 |  WARNING Not Found: /ocd-bill/28cb5a12-57f2-40cf-8bc2-f132cf52290e
2:10:50 PM web.1 |  WARNING Not Found: /ocd-bill/05eaa39e-d9a0-4574-8ddc-70a9997be4a6
2:10:50 PM web.1 |  WARNING Not Found: /ocd-bill/89c760b3-0ecd-4226-a744-99ab1ff5daa6
```