### PR TITLE
Add option to avoid using unstable OCD_CITY_COUNCIL_ID

### DIFF
--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -6,9 +6,9 @@ from django.conf import settings
 import inspect
 import importlib
 
-if not hasattr(settings, 'OCD_CITY_COUNCIL_ID'):
+if not (hasattr(settings, 'OCD_CITY_COUNCIL_ID') or hasattr(settings, 'OCD_CITY_COUNCIL_NAME')):
     raise ImproperlyConfigured(
-        'You must define a OCD_COUNCIL_ID in settings.py')
+        'You must define a OCD_CITY_COUNCIL_ID or OCD_CITY_COUNCIL_NAME in settings.py')
 
 if not hasattr(settings, 'CITY_COUNCIL_NAME'):
     raise ImproperlyConfigured(
@@ -66,8 +66,10 @@ class Person(models.Model):
 
     @property
     def latest_council_membership(self):
-        city_council_id = settings.OCD_CITY_COUNCIL_ID
-        filter_kwarg = {'_organization__ocd_id': city_council_id}
+        if hasattr(settings, 'OCD_CITY_COUNCIL_ID'):
+            filter_kwarg = {'_organization__ocd_id': settings.OCD_CITY_COUNCIL_ID}
+        else:
+            filter_kwarg = {'_organization__name': settings.OCD_CITY_COUNCIL_NAME}
 
         city_council_memberships = self.memberships.filter(**filter_kwarg)
 

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -150,9 +150,12 @@ class CouncilMembersView(ListView):
     context_object_name = 'posts'
 
     def get_queryset(self):
-        return Organization.objects.get(ocd_id=settings.OCD_CITY_COUNCIL_ID).posts.all()
-        # return
-        # Post.objects.filter(organization__ocd_id=settings.OCD_CITY_COUNCIL_ID)
+        if hasattr(settings, 'OCD_CITY_COUNCIL_ID'):
+            get_kwarg = {'ocd_id': settings.OCD_CITY_COUNCIL_ID}
+        else:
+            get_kwarg = {'name': settings.OCD_CITY_COUNCIL_NAME}
+
+        return Organization.objects.get(**get_kwarg).posts.all()
 
     def get_context_data(self, *args, **kwargs):
         context = super(CouncilMembersView, self).get_context_data(**kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,4 @@
 [flake8]
 ignore = E501,E731
+# E501 line too long (X > 79 characters)
+# E731 do not assign a lambda expression, use a def


### PR DESCRIPTION
In the Canadian scrapers in scrapers-ca repo (hosted at http://scrapers.herokuapp.com/), we've made the choice to blow away the db regularly, and so OCD ids change. This is arguably something that we should eventually rethink, but for now, it's not an issue. Except in one place :)

https://github.com/datamade/django-councilmatic/blob/6d81da28435a31eff1e7f35662515a20aa935417/councilmatic_core/models.py#L67

https://github.com/datamade/chi-councilmatic/blob/master/councilmatic/settings_jurisdiction.py#L7

Would it be possible to instead use `_organization__name` instead of `organization__ocd_id` as the filter, as this is consistent and won't lead to odd behaviour whenever we re-run loaddata.

cc: @jpmckinney