### PR TITLE
Fix javascript sort order to honor template priority of chair roles

### DIFF
--- a/councilmatic_core/templates/councilmatic_core/committee.html
+++ b/councilmatic_core/templates/councilmatic_core/committee.html
@@ -145,17 +145,28 @@
     <script src="{% static 'js/dataTables.bootstrap.js' %}"></script>
 
     <script>
+        var ROLE_SORT_ORDER = ["Member", "Vice Chair", "Vice Chairperson", "Chair", "Chairperson"];
+        {% if COMMITTEE_MEMBER_TITLE %}ROLE_SORT_ORDER.unshift('{{COMMITTEE_MEMBER_TITLE|escapejs}}');{% endif %}
+        {% if COMMITTEE_CHAIR_TITLE %}ROLE_SORT_ORDER.pop('{{COMMITTEE_CHAIR_TITLE|escapejs}}');{% endif %}
+
+        jQuery.fn.dataTableExt.oSort["role-desc"] = function(a, b) {
+          return ROLE_SORT_ORDER.indexOf(b) - ROLE_SORT_ORDER.indexOf(a);
+        };
+        jQuery.fn.dataTableExt.oSort["role-asc"] = function(a, b) {
+          return ROLE_SORT_ORDER.indexOf(a) - ROLE_SORT_ORDER.indexOf(b);
+        };
+
         $("#council-members").DataTable({
             "info": false,
             "searching": false,
             "bLengthChange": false,
             "paging": false,
-            "aaSorting": [ [3,'asc'] ],
+            "aaSorting": [ [3,'desc'] ],
             "aoColumns": [
                 { "bSortable": false },
                 null,
                 { "sType": "num-html" },
-                null
+                { "sType": "role" }
             ]
         });
 

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -77,6 +77,8 @@ def city_context(request):
         'CITY_NAME',
         'CITY_NAME_SHORT',
         'CITY_VOCAB',
+        'COMMITTEE_CHAIR_TITLE',
+        'COMMITTEE_MEMBER_TITLE',
         'SEARCH_PLACEHOLDER_TEXT',
         'LEGISLATION_TYPE_DESCRIPTIONS',
         'LEGISTAR_URL',


### PR DESCRIPTION
Ref: https://github.com/datamade/django-councilmatic/issues/61#issuecomment-206565804

Ok, bad news :( The approach mentioned in the above link doesn't seem to work as expected, so I think this is a bug.

The template doesn't actually sort with chairs at the top, it just so happens that lexicographic sort puts "Chairperson" above "Member". When I tweak the members filter to find chair roles that *contain* "Chair" (ie. both "Vice Chair" and "Chair"), and also for the view to display the underlying label (ie. not "Chairperson"), then "Vice Chair" goes to the bottom in a fresh browser reload:

![](https://imgur.com/XT8zTdt.png)