### PR TITLE
Search page breaks when posts exist without memberships

### DIFF
--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -531,7 +531,7 @@ class Post(models.Model):
 
     @property
     def current_member(self):
-        if self.memberships:
+        if self.memberships.all():
             most_recent_member = self.memberships.order_by(
                 '-start_date', '-end_date').first()
             if most_recent_member.end_date:

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -50,7 +50,8 @@ class CouncilmaticFacetedSearchView(FacetedSearchView):
         extra['selected_facets'] = selected_facets
 
         extra['current_council_members'] = {
-            p.current_member.person.name: p.label for p in Post.objects.all()}
+            p.current_member.person.name: p.label for p in Post.objects.all() if p.current_member
+        }
 
         return extra
 


### PR DESCRIPTION
Seems like some ~~roles~~ posts might be vacant (ie. a vice chair or a deceased member for a short while), and this should be accommodated.