### PR TITLE
Make no results iterable

### DIFF
--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -133,14 +133,14 @@ class Person(models.Model):
         if hasattr(settings, 'COMMITTEE_CHAIR_TITLE'):
             return self.memberships.filter(role=settings.COMMITTEE_CHAIR_TITLE)
         else:
-            return None
+            return []
 
     @property
     def member_role_memberships(self):
         if hasattr(settings, 'COMMITTEE_MEMBER_TITLE'):
             return self.memberships.filter(role=settings.COMMITTEE_MEMBER_TITLE)
         else:
-            return None
+            return []
 
 
 class Bill(models.Model):
@@ -220,7 +220,7 @@ class Bill(models.Model):
         """
         returns all actions ordered by date in descending order
         """
-        return self.actions.all().order_by('-order') if self.actions.all() else None
+        return self.actions.all().order_by('-order')
     
     @property
     def current_action(self):
@@ -279,7 +279,7 @@ class Bill(models.Model):
 
             return list(orgs)
         else:
-            return None
+            return []
 
     @property
     def topics(self):
@@ -288,7 +288,7 @@ class Bill(models.Model):
 
         override this in custom subclass for richer topic logic
         """
-        return None
+        return []
 
     @property
     def addresses(self):
@@ -400,7 +400,7 @@ class Organization(models.Model):
     def recent_activity(self):
         # setting arbitrary max of 300 b/c otherwise page will take forever to
         # load
-        return self.actions.order_by('-date', '-_bill__identifier', '-order')[:300] if self.actions.all() else None
+        return self.actions.order_by('-date', '-_bill__identifier', '-order')[:300]
 
     @property
     def recent_events(self):
@@ -427,14 +427,14 @@ class Organization(models.Model):
         if hasattr(settings, 'COMMITTEE_CHAIR_TITLE'):
             return self.memberships.filter(role=settings.COMMITTEE_CHAIR_TITLE)
         else:
-            return None
+            return []
 
     @property
     def non_chair_members(self):
         if hasattr(settings, 'COMMITTEE_MEMBER_TITLE'):
             return self.memberships.filter(role=settings.COMMITTEE_MEMBER_TITLE)
         else:
-            return None
+            return []
 
     @property
     def link_html(self):


### PR DESCRIPTION
There are quite a few places in the models where, if no results exist, we return `None`. But there are quite a few places where a queryset is assumed to have results, and we chain it as if it's an iterable.

Can we start returning an empty list i n these places so that we don't need to keep accommodating special cases?

Example:
* https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/models.py#L400-L403
* https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/feeds.py#L188