### PR TITLE
[WIP] Controlled Legislation in Committee Views

### DIFF
--- a/councilmatic_core/templates/councilmatic_core/committee.html
+++ b/councilmatic_core/templates/councilmatic_core/committee.html
@@ -84,7 +84,46 @@
                 {% endfor %}
                 <a href="" id="more-events"><i class="fa fa-fw fa-chevron-down"></i>Show more</a>
                 <a href="" id="fewer-events"><i class="fa fa-fw fa-chevron-up"></i>Show fewer</a>
-            {% endif %}
+	    {% endif %}
+
+		<hr />
+
+		<h4>
+		    <i class='fa fa-fw fa-list-ul'></i> Legislation in Committee
+                </h4>
+
+            <div class="table-responsive">
+                <table class='table' id='committee-actions'>
+                    <thead>
+                        <tr>
+                            <th>Action</th>
+                            <th>Legislation</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for bill in committee.controlled_bills %}
+                            <tr>
+                                <td class='nowrap'>
+                                    <p class="text-muted small no-pad-bottom">
+                                        {{bill.last_action_date|date:'n/d/Y'}}
+                                    </p>
+                                </td>
+                                <td>
+                                    <p class="small no-pad-bottom">
+                                        <a href="/legislation/{{bill.slug}}/">{{bill.friendly_name}}</a>
+                                    </p>
+                                    <p class="small no-pad-bottom">
+                                        {{bill.description | short_blurb}}
+                                    </p>
+                                </td>
+                            </tr>
+                        {% endfor %}
+		    </tbody>
+		</table>
+	    </div>
+
+
+		
 
             <hr />
             <h4><i class='fa fa-fw fa-group'></i> Committee Members ({{ committee.memberships.all|length }})</h4>


### PR DESCRIPTION
In many legislatures, committees are the main site of action. In particular, whether a piece of legislation is ever dealt with by a committee determines it's fate.

This pull request adds a list to committee pages of all the legislation that is currently under control of the legislation.

Relates to https://github.com/datamade/chi-councilmatic/issues/69

Here's stuff stuck in the Chicago Rules committee:
![screenshot from 2016-07-16 23-36-03](https://cloud.githubusercontent.com/assets/536941/16898776/1cf7733c-4bae-11e6-9c3a-9e8a37459411.png)
