### PR TITLE
Remove iterative process from index page, and import last_action-date

### DIFF
--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -4,7 +4,7 @@ import itertools
 from operator import attrgetter
 import urllib
 import requests
-from datetime import date, timedelta, datetime
+from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
 from dateutil import parser
 
@@ -173,6 +173,7 @@ class IndexView(TemplateView):
         # Example: https://github.com/datamade/django-councilmatic/blob/154028d1bc4639fa1ec1af75139cab544abdd315/councilmatic_core/views.py#L139
 
         return recently_passed
+
 
 class AboutView(TemplateView):
     template_name = 'councilmatic_core/about.html'

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -145,27 +145,7 @@ class IndexView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(IndexView, self).get_context_data(**kwargs)
 
-        recently_passed = []
-        # go back in time at 10-day intervals til you find 3 passed bills
-        for i in range(0, -100, -10):
-
-            today = timezone.now()
-
-            begin = today + timedelta(days=i)
-            end = today + timedelta(days=i - 10)
-
-            leg_in_range = self.bill_model.objects\
-                .exclude(last_action_date=None)\
-                .filter(last_action_date__lte=begin)\
-                .filter(last_action_date__gt=end)\
-                .order_by('-last_action_date')
-            passed_in_range = [l for l in leg_in_range
-                               if l.inferred_status == 'Passed']
-
-            recently_passed.extend(passed_in_range)
-            if len(recently_passed) >= 3:
-                recently_passed = recently_passed[:3]
-                break
+        recently_passed = self.find_recently_passed(self.bill_model)
 
         upcoming_meetings = list(
             self.event_model.upcoming_committee_meetings())
@@ -186,6 +166,13 @@ class IndexView(TemplateView):
         """
         return {}
 
+    def find_recently_passed(self, bill_model):
+        recently_passed = []
+        # Do you want to show recently passed bills? CUSTOMIZE FOR COUNCILMATIC.
+        # Otherwise avoid any unnecessary iterative processes when loading the index.
+        # Example: https://github.com/datamade/django-councilmatic/blob/154028d1bc4639fa1ec1af75139cab544abdd315/councilmatic_core/views.py#L139
+
+        return recently_passed
 
 class AboutView(TemplateView):
     template_name = 'councilmatic_core/about.html'


### PR DESCRIPTION
This PR addresses two related issues:
(1) It adds logic to import_data to retrieve the `last_action_date` for bills;
(2) It removes [an unnecessary, memory-hungry iterative process from the Index view](https://sentry.io/datamade/lametro-councilmatic/issues/411033453/) - an iteration that did not serve any of our Councilmatics.