### PR TITLE
Remove update and send commands from import

### DIFF
--- a/councilmatic_core/management/commands/import_data.py
+++ b/councilmatic_core/management/commands/import_data.py
@@ -102,12 +102,6 @@ class Command(BaseCommand):
                             default=False,
                             help='Only download OCD data')
 
-        parser.add_argument('--no_index',
-                            action='store_true',
-                            default=False,
-                            help='Only download OCD data')
-
-
     def handle(self, *args, **options):
 
         self.connection = engine.connect()
@@ -150,22 +144,6 @@ class Command(BaseCommand):
                 except Exception as e:
                     client.captureException()
                     logger.error(e, exc_info=True)
-
-
-        if not options['no_index'] and getattr(settings, 'USING_NOTIFICATIONS', None):
-            from django.core import management
-
-            try:
-                management.call_command('update_index', age=24)
-            except Exception as e:
-                client.captureException()
-                logger.error(e, exc_info=True)
-
-            try:
-                management.call_command('send_notifications')
-            except Exception as e:
-                client.captureException()
-                logger.error(e, exc_info=True)
 
 
     def log_message(self,


### PR DESCRIPTION
This PR handles issue #168.

What does this mean for Councilmatics that use notifications? 

Cron needs to execute two commands:
(1) python manage.py update_index (note: each Councilmatic may have different args, but we _do not_ want to hard code the `age=24` arg, as we did previously)
(2) python manage.py send_notifications

These commands should fire in sequence. So, for NYC Councilmatic we'd have:

`10,25,40,55 * * * * datamade /usr/bin/flock -n /tmp/nyc_dataload.lock -c 'cd /home/datamade/nyc-council-councilmatic && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py import_data >> /tmp/nyc-council-councilmatic-loaddata.log 2>&1 && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py update_index --batch-size=50 >> /tmp/nyc-council-councilmatic-updateindex.log 2>&1 && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py update_index --batch-size=50 >> /tmp/nyc-council-councilmatic-updateindex.log 2>&1 && /home/datamade/.virtualenvs/nyc-council-councilmatic/bin/python manage.py convert_rtf >> /tmp/convert_rtf.log 2>&1'`