### PR TITLE
Data integrity

### DIFF
--- a/councilmatic_core/management/commands/convert_rtf.py
+++ b/councilmatic_core/management/commands/convert_rtf.py
@@ -15,6 +15,7 @@ from django.db.models import Max
 from councilmatic_core.models import Bill
 
 logging.config.dictConfig(settings.LOGGING)
+logging.getLogger("requests").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 DB_CONN = 'postgresql://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}'

--- a/councilmatic_core/management/commands/data_integrity.py
+++ b/councilmatic_core/management/commands/data_integrity.py
@@ -1,0 +1,42 @@
+import pysolr
+import requests
+import logging
+import logging.config
+
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+
+from councilmatic_core.models import Bill
+
+
+logging.config.dictConfig(settings.LOGGING)
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("pysolr").setLevel(logging.WARNING)
+logger = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    help = 'Checks for alignment between the Solr index and Councilmatic database'
+
+    def handle(self, *args, **options):
+        councilmatic_count = Bill.objects.all().count()
+
+        try:
+            solr_url = settings.HAYSTACK_CONNECTIONS['default']['URL']
+            requests.get(solr_url)
+        except requests.ConnectionError:
+            message = "ConnectionError: Unable to connect to Solr at {}. Is Solr running?".format(solr_url)
+            logger.error(message)
+            raise Exception(message)
+
+        solr = pysolr.Solr(solr_url)
+        solr_index_count = solr.search(q='*:*').hits
+
+        if solr_index_count != councilmatic_count:
+            message = 'Solr index has {solr} entites. The Councilmatic database has {councilmatic} entities. That\'s a problem!'.format(solr=solr_index_count, councilmatic=councilmatic_count)
+            logger.error(message)
+            print('. . . . .\n')
+
+            raise AssertionError(message)
+
+        logger.info('Good news! Solr index has {solr} entites. The Councilmatic database has {councilmatic} entities.'.format(solr=solr_index_count, councilmatic=councilmatic_count))
+        print('. . . . .\n')

--- a/councilmatic_core/management/commands/data_integrity.py
+++ b/councilmatic_core/management/commands/data_integrity.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
             solr_url = settings.HAYSTACK_CONNECTIONS['default']['URL']
             requests.get(solr_url)
         except requests.ConnectionError:
-            message = "ConnectionError: Unable to connect to Solr at {}. Is Solr running?".format(solr_url)
+            message = "ConnectionError: Unable to connect to Solr at {} when running the data integrity check. Is Solr running?".format(solr_url)
             logger.error(message)
             raise Exception(message)
 

--- a/councilmatic_core/management/commands/import_data.py
+++ b/councilmatic_core/management/commands/import_data.py
@@ -34,7 +34,6 @@ from councilmatic_core.models import Person, Bill, Organization, Action, ActionR
 
 
 logging.config.dictConfig(settings.LOGGING)
-logging.getLogger("requests").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)

--- a/councilmatic_core/management/commands/import_data.py
+++ b/councilmatic_core/management/commands/import_data.py
@@ -34,6 +34,7 @@ from councilmatic_core.models import Person, Bill, Organization, Action, ActionR
 
 
 logging.config.dictConfig(settings.LOGGING)
+logging.getLogger("requests").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)


### PR DESCRIPTION
This PR adds a management command which verifies that Solr indexed all Councilmatic bills (no more, no less). 

We will use it with Metro and implement elsewhere, if desired. Relates to this Metro issue: https://github.com/datamade/la-metro-councilmatic/issues/256