### PR TITLE
Return unique identifiers only

### DIFF
--- a/councilmatic_core/templatetags/extras.py
+++ b/councilmatic_core/templatetags/extras.py
@@ -104,7 +104,7 @@ def alternative_identifiers(id_original):
     id_1 = re.sub(" ", " 0", id_original)
     id_2 = re.sub(" ", "", id_original)
     id_3 = re.sub(" ", "", id_1)
-    return id_original + ' ' + id_1 + ' ' + id_2 + ' ' + id_3
+    return ' '.join(i for i in set([id_original, id_1, id_2, id_3]))
 
 
 @register.filter


### PR DESCRIPTION
Sometimes alt identifiers are the same as the regular identifier. This updates the `alternative_identifiers` filter to return a `set` of – e.g., unique – identifiers.

Addresses https://github.com/datamade/la-metro-councilmatic/issues/258