### PR TITLE
Use legislative session from OCD

### DIFF
--- a/councilmatic_core/management/commands/import_data.py
+++ b/councilmatic_core/management/commands/import_data.py
@@ -991,7 +991,7 @@ class Command(BaseCommand):
                 'ocr_full_text': ocr_full_text,
                 'html_text': html_text,
                 'abstract': abstract,
-                'legislative_session_id': '{0}-{1}'.format(bill_info['legislative_session']['identifier'], self.jurisdiction_name),
+                'legislative_session_id': bill_info['legislative_session']['identifier'],
                 'bill_type': bill_type,
                 'slug': slug,
             }


### PR DESCRIPTION
Reverts a line from last release, fixing bug where we introduced inconsistency w data source.