### PR TITLE
Put downloads in the city-specific Councilmatic instance

### DIFF
--- a/councilmatic_core/management/commands/import_data.py
+++ b/councilmatic_core/management/commands/import_data.py
@@ -111,9 +111,8 @@ class Command(BaseCommand):
 
             self.jurisdiction_id = jurisdiction_id
             self.jurisdiction_name = jurisdiction_id.rsplit(':', 1)[1].split('/')[0]
-
-            self.downloads_folder = os.path.join(self.this_folder,
-                                                 'downloads',
+            
+            self.downloads_folder = os.path.join('downloads',
                                                  self.jurisdiction_name)
 
             self.organizations_folder = os.path.join(self.downloads_folder, 'organizations')


### PR DESCRIPTION
This PR insures that downloaded data appears in a downloads folder in the Councilmatic instance, rather than the django-councilmatic directory in the virtualenv. 