### PR TITLE
Append jurisdiction name to bill slugs

### DIFF
--- a/councilmatic_core/management/commands/import_data.py
+++ b/councilmatic_core/management/commands/import_data.py
@@ -974,7 +974,8 @@ class Command(BaseCommand):
             else:
                 raise Exception(bill_info['classification'])
 
-            slug = slugify(bill_info['identifier'])
+            slug = slugify('{0} {1}'.format(self.jurisdiction_name, 
+                                            bill_info['identifier']))
 
             insert = {
                 'ocd_id': bill_info['id'],

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
                       'SQLAlchemy>=1.1.2,<1.2',
                       'psycopg2>=2.7',
                       'django-password-reset>=0.9,<1.0',
-                      'django-councilmatic-notifications<0.2',
                       'django-adv-cache-tag==1.1.0'],
     classifiers=[
         'Environment :: Web Environment',

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -65,8 +65,6 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'councilmatic_core',
     'haystack',
-    'notifications',
-    'django_rq',
     'password_reset',
     'adv_cache_tag',
 )


### PR DESCRIPTION
It turns out that when you have more than one jurisdiction, that doesn't necessarily mean that the bill identifiers are globally unique. This PR appends a slugified version of the jurisdiction name that is extracted from the OCD division identifier for the jurisdiction and adds it into the slug so that the bill identifiers only need to be unique within a given jurisdiction in order for the slugs to be unique.  