### PR TITLE
Init correct model in EventMedia model

### DIFF
--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -774,7 +774,7 @@ class EventMedia(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     def __init__(self, *args, **kwargs):
-        super(EventParticipant, self).__init__(*args, **kwargs)
+        super(EventMedia, self).__init__(*args, **kwargs)
         self.event = override_relation(self.event)
 
 


### PR DESCRIPTION
This PR fixes a bug where an EventMedia object cannot be instantiated because it was trying to instantiate an `EventParticipant` object by mistake.