### PR TITLE
Break search bar into partial

### DIFF
--- a/councilmatic_core/templates/partials/search_bar.html
+++ b/councilmatic_core/templates/partials/search_bar.html
@@ -1,0 +1,6 @@
+<input name="q" type="text" class="input-lg form-control" placeholder="{{ SEARCH_PLACEHOLDER_TEXT }}" value="{{ formatted_q }}">
+<div class='input-group-btn'>
+    <button type="submit" class="btn btn-lg btn-primary">
+        <i class='fa fa-fw fa-search'></i>
+    </button>
+</div>

--- a/councilmatic_core/templates/search/search.html
+++ b/councilmatic_core/templates/search/search.html
@@ -36,12 +36,9 @@
                     <input name="sort_by" type="hidden" class="form-control" value="relevance">
                 {% endif %}
 
-                <input name="q" type="text" class="input-lg form-control" placeholder="{{SEARCH_PLACEHOLDER_TEXT}}" {% if request.GET.q %}value="{{request.GET.q|remove_question}}"{% endif %}>
-                <div class='input-group-btn'>
-                    <button type="submit" class="btn btn-lg btn-primary">
-                        <i class='fa fa-fw fa-search'></i>
-                    </button>
-                </div>
+                {% with formatted_q=request.GET.q|remove_question %}
+                    {% include 'partials/search_bar.html' %}
+                {% endwith %}
             </div>
         </form>
     </div>


### PR DESCRIPTION
We're adding the ability to search attachment text, as will as bill text, to LA Metro. This requires a toggle-able input to search the full corpus or only bills. Break the search bar into its own partial so additional search options, like this one, can be added downstream.

For posterity, [here's an example](https://github.com/datamade/la-metro-councilmatic/blob/15e6a8d393fbdbd9e6826f9d85540f1ef45f8e1e/lametro/templates/partials/search_bar.html) of how this is overriden downstream.