### PR TITLE
Check for nested values in agenda items Dict using

### DIFF
--- a/councilmatic_core/management/commands/import_data.py
+++ b/councilmatic_core/management/commands/import_data.py
@@ -3224,10 +3224,10 @@ class Command(BaseCommand):
                     pass
 
                 notes = ''
-                if item['notes']:
+                if item.get('notes'):
                     notes = item['notes'][0]
 
-                if item['extras'].get('plain_text'):
+                if item.get('extras', {}).get('plain_text'):
                     plain_text = item['extras']['plain_text']
                 else:
                     plain_text = None


### PR DESCRIPTION
@evz - Metro agenda items do not include an "extras" field (e.g., https://ocd.datamade.us/ocd-event/4ebaeaa8-22d7-40df-bf4b-a9d4302ecd82/). This change avoids annoying kay value errors.