### PR TITLE
Refactor search-order

### DIFF
--- a/councilmatic_core/static/css/custom.css
+++ b/councilmatic_core/static/css/custom.css
@@ -265,7 +265,9 @@ h1, h2, h3, h4 {
     border-radius: 0;
 }
 
-
+.order-nav a.nav-link {
+    margin-left: 1.8em;
+}
 
 
 /* bill detail listing */

--- a/councilmatic_core/templates/partials/component_bill_type_table.html
+++ b/councilmatic_core/templates/partials/component_bill_type_table.html
@@ -11,7 +11,7 @@
             <td>
                 <p class='nowrap'>
                     <i class="fa fa-fw fa-{{leg_type.fa_icon}}"></i>
-                    <a href="/search/?selected_facets=bill_type_exact%3A{{leg_type.search_term}}&_={{timestamp}}">{{leg_type.name}}</a>
+                    <a href="/search/?selected_facets=bill_type_exact%3A{{leg_type.search_term}}">{{leg_type.name}}</a>
                 </p>
 
                 <div class="non-desktop-only">

--- a/councilmatic_core/templates/partials/order_by_filter.html
+++ b/councilmatic_core/templates/partials/order_by_filter.html
@@ -1,49 +1,22 @@
 {% load extras %}
 
 {% if 'sort_by='|add:order_name in request.get_full_path %}
-    <a class="sort-by nav-link" href="{{ request.get_full_path | format_url_parameters }}" data='sort_by='|add:order_name>
-        <strong>{{order_name|title}}</strong>
-    </a>
+    <strong><a class="sort-by nav-link" href="{% search_with_querystring request sort_by=order_name %}" data='sort_by={{order_name}}'>
+        {{order_name|title}}
+        {% search_with_querystring request sort_by=order_name %}
+    </a></strong>
 
-    {% if 'sort_by=date' in request.get_full_path %}
-        {% if 'ascending' in request.get_full_path %}
-            {% if 'page=' in request.get_full_path %}
-                <a class="nav-link assort" href="{{ request.get_full_path | format_url_parameters }}&amp;sort_by=date" data="sort_by=date">
-                    <i class="fa fa-sort-amount-asc" aria-hidden="true"></i>
-                </a>
-            {% else %}
-                <a class="nav-link assort" href="{{ request.get_full_path | format_url_parameters }}?&amp;sort_by=date" data="sort_by=date">
-                    <i class="fa fa-sort-amount-asc" aria-hidden="true"></i>
-                </a>
-            {% endif %}
-        {% else %}
-            <a class="nav-link assort" href="{{ request.get_full_path }}&amp;ascending=true" data="ascending=true">
-                <i class="fa fa-sort-amount-desc" aria-hidden="true"></i>
-            </a>
-        {% endif %}
-    {% elif 'sort_by=title' in request.get_full_path%}
-        {% if 'descending' in request.get_full_path %}
-            {% if 'page=' in request.get_full_path %}
-                <a class="nav-link assort" href="{{ request.get_full_path | format_url_parameters }}&amp;sort_by=title" data='sort_by=title'>
-                    <i class="fa fa-sort-amount-desc" aria-hidden="true"></i>
-                </a>
-            {% else %}
-                <a class="nav-link assort" href="{{ request.get_full_path | format_url_parameters }}?&amp;sort_by=title" data="sort_by=title">
-                    <i class="fa fa-sort-amount-desc" aria-hidden="true"></i>
-                </a>
-            {% endif %}
-        {% else %}
-            <a class="nav-link assort" href="{{ request.get_full_path }}&amp;descending=true" data="descending=true">
-                 <i class="fa fa-sort-amount-asc" aria-hidden="true"></i>
-            </a>
-        {% endif %}
+    <!-- Add an icon to indicate direction of sort -->
+    {% if 'sort_by=date' in request.get_full_path or 'sort_by=title' in request.get_full_path %}
+        {% sort_direction request as dir %}
+        <strong><a class="nav-link assort" href="{% search_with_querystring request sort_by=order_name order_by=dir %}" data='sort_by={{order_name}}'>
+            <i class="fa fa-sort-amount-{{ dir }}" aria-hidden="true"></i>
+        </a></strong>
     {% endif %}
-{% elif 'page=' in request.get_full_path %}
-    <a class="sort-by nav-link" href="{{ request.get_full_path | format_url_parameters }}&amp;sort_by={{ order_name }}" data='sort_by='|add:order_name>
-        {{order_name|title}}
-    </a>
+
 {% else %}
-    <a class="sort-by nav-link" href="{{ request.get_full_path | format_url_parameters }}?&amp;sort_by={{ order_name }}" data='sort_by='|add:order_name>
+    <a class="sort-by nav-link" href="{% search_with_querystring request sort_by=order_name %}" data='sort_by={{order_name}}'>
         {{order_name|title}}
+        {% search_with_querystring request sort_by=order_name %}
     </a>
 {% endif %}

--- a/councilmatic_core/templates/partials/order_by_filter.html
+++ b/councilmatic_core/templates/partials/order_by_filter.html
@@ -1,22 +1,22 @@
 {% load extras %}
 
-{% if 'sort_by='|add:order_name in request.get_full_path %}
-    <strong><a class="sort-by nav-link" href="{% search_with_querystring request sort_by=order_name %}" data='sort_by={{order_name}}'>
-        {{order_name|title}}
-        {% search_with_querystring request sort_by=order_name %}
-    </a></strong>
-
-    <!-- Add an icon to indicate direction of sort -->
+{% if 'sort_by='|add:sort_name in request.get_full_path %}
+    <!-- Add an icon to indicate direction of sort; not needed for relevance filter -->
     {% if 'sort_by=date' in request.get_full_path or 'sort_by=title' in request.get_full_path %}
         {% sort_direction request as dir %}
-        <strong><a class="nav-link assort" href="{% search_with_querystring request sort_by=order_name order_by=dir %}" data='sort_by={{order_name}}'>
+        <strong><a class="nav-link assort" href="{% search_with_querystring request sort_by=sort_name order_by=dir|reverse_sort %}" data='sort_by={{sort_name}}'>
+            {{sort_name|title}}
+            <!-- Put current direction in URL -->
             <i class="fa fa-sort-amount-{{ dir }}" aria-hidden="true"></i>
+        </a></strong>
+    {% else %}
+        <strong><a class="sort-by nav-link" href="{% search_with_querystring request sort_by=sort_name order_by='' %}" data='sort_by={{sort_name}}'>
+            {{sort_name|title}}
         </a></strong>
     {% endif %}
 
 {% else %}
-    <a class="sort-by nav-link" href="{% search_with_querystring request sort_by=order_name %}" data='sort_by={{order_name}}'>
-        {{order_name|title}}
-        {% search_with_querystring request sort_by=order_name %}
+    <a class="sort-by nav-link" href="{% search_with_querystring request sort_by=sort_name order_by=order_name %}" data='sort_by={{sort_name}}'>
+        {{sort_name|title}}
     </a>
 {% endif %}

--- a/councilmatic_core/templates/partials/order_by_filter.html
+++ b/councilmatic_core/templates/partials/order_by_filter.html
@@ -1,20 +1,12 @@
 {% load extras %}
 
 {% if 'sort_by='|add:sort_name in request.get_full_path %}
-    <!-- Add an icon to indicate direction of sort; not needed for relevance filter -->
-    {% if 'sort_by=date' in request.get_full_path or 'sort_by=title' in request.get_full_path %}
-        {% sort_direction request as dir %}
-        <strong><a class="nav-link assort" href="{% search_with_querystring request sort_by=sort_name order_by=dir|reverse_sort %}" data='sort_by={{sort_name}}'>
-            {{sort_name|title}}
-            <!-- Put current direction in URL -->
-            <i class="fa fa-sort-amount-{{ dir }}" aria-hidden="true"></i>
-        </a></strong>
-    {% else %}
-        <strong><a class="sort-by nav-link" href="{% search_with_querystring request sort_by=sort_name order_by='' %}" data='sort_by={{sort_name}}'>
-            {{sort_name|title}}
-        </a></strong>
-    {% endif %}
-
+    {% sort_direction request as dir %}
+    <strong><a class="nav-link assort" href="{% search_with_querystring request sort_by=sort_name order_by=dir|reverse_sort %}" data='sort_by={{sort_name}}'>
+        {{sort_name|title}}
+        <!-- Put current direction in URL -->
+        <i class="fa fa-sort-amount-{{ dir }}" aria-hidden="true"></i>
+    </a></strong>
 {% else %}
     <a class="sort-by nav-link" href="{% search_with_querystring request sort_by=sort_name order_by=order_name %}" data='sort_by={{sort_name}}'>
         {{sort_name|title}}

--- a/councilmatic_core/templates/search/indexes/councilmatic_core/bill_text.txt
+++ b/councilmatic_core/templates/search/indexes/councilmatic_core/bill_text.txt
@@ -14,5 +14,4 @@
 {% for t in object.topics %}
 	{{t}}
 {% endfor %}
-{{ object.full_text|clean_html }}
 {{ object.ocr_full_text|clean_html }}

--- a/councilmatic_core/templates/search/search.html
+++ b/councilmatic_core/templates/search/search.html
@@ -110,15 +110,15 @@
 
                 Order by:
 
-                {% with order_name='date' %}
+                {% with sort_name='date' order_name='desc' %}
                     {% include 'partials/order_by_filter.html' %}
                 {% endwith %}
 
-                {% with order_name='title' %}
+                {% with sort_name='title' order_name='asc' %}
                     {% include 'partials/order_by_filter.html' %}
                 {% endwith %}
 
-                {% with order_name='relevance' %}
+                {% with sort_name='relevance' order_name='' %}
                     {% include 'partials/order_by_filter.html' %}
                 {% endwith %}
 
@@ -315,10 +315,10 @@
                 var addtl_filter = $(this).attr('data');
 
                 if(existing_q){
-                    window.location.assign('/search/?'+existing_q+'&selected_facets='+encodeURIComponent(addtl_filter)+"&_="+timestamp);
+                    window.location.assign('/search/?'+existing_q+'&selected_facets='+encodeURIComponent(addtl_filter));
                 }
                 else{
-                    window.location.assign ('/search/?selected_facets=' + encodeURIComponent(addtl_filter)+"&_="+timestamp);
+                    window.location.assign ('/search/?selected_facets=' + encodeURIComponent(addtl_filter));
                 };
 
             });
@@ -332,7 +332,7 @@
                     return encodeURIComponent(value) != to_remove;
                 });
 
-                window.location.assign('/search/?' + new_components.join('&')+"&_="+timestamp);
+                window.location.assign('/search/?' + new_components.join('&'));
             });
 
             $(".remove-order-value").click(function() {
@@ -341,12 +341,12 @@
 
                 for(var i = existing_components.length -1; i >= 0 ; i--){
                     var el = existing_components[i]
-                    if(el.includes('ascending') || el.includes(to_remove) || el.includes('descending')) {
+                    if(el.includes('asc') || el.includes(to_remove) || el.includes('desc')) {
                         existing_components.splice(i, 1);
                     }
                 }
 
-                window.location.assign('/search/?' + existing_components.join('&')+"&_="+timestamp);
+                window.location.assign('/search/?' + existing_components.join('&'));
             });
 
         });

--- a/councilmatic_core/templates/search/search.html
+++ b/councilmatic_core/templates/search/search.html
@@ -315,7 +315,6 @@
                 }
             });
 
-            var timestamp = Date.now();
             var existing_q = decodeURIComponent("{{ q_filters }}").replace(/&amp;/g, '&').replace(/\+/g, ' ');
 
             $(".filter-value").click(function() {

--- a/councilmatic_core/templates/search/search.html
+++ b/councilmatic_core/templates/search/search.html
@@ -106,7 +106,7 @@
 
         <div class="col-sm-8 order-nav">
 
-            <nav class="nav nav-inline">
+            <nav class="nav nav-inline order-nav">
 
                 Order by:
 
@@ -118,9 +118,16 @@
                     {% include 'partials/order_by_filter.html' %}
                 {% endwith %}
 
-                {% with sort_name='relevance' order_name='' %}
-                    {% include 'partials/order_by_filter.html' %}
-                {% endwith %}
+                <!-- The templating logic is different for Relevance sort. The Relevance sort does not require a direction, and it should be bolded by default after submitting a query.-->
+                {% if 'sort_by=relevance' in request.get_full_path or 'order_by=' not in request.get_full_path and 'q=' in request.get_full_path %}
+                    <strong><a class="nav-link assort" href="{% search_with_querystring request sort_by='relevance' %}" data='sort_by=relevance'>
+                        Relevance
+                    </a></strong>
+                {% else %}
+                    <a class="sort-by nav-link" href="{% search_with_querystring request sort_by='relevance' %}" data='sort_by=relevance'>
+                        Relevance
+                    </a>
+                {% endif %}
 
                 {% if 'sort_by' in request.get_full_path %}
                     <a href ="#" class="remove-order-value btn btn-sm btn-primary hidden-xs"

--- a/councilmatic_core/templatetags/extras.py
+++ b/councilmatic_core/templatetags/extras.py
@@ -120,35 +120,27 @@ def format_date_sort(s, fmt='%Y%m%d%H%M'):
         return '0'
 
 
-@register.filter
-def format_url_parameters(url):
-    params = ["?&sort_by=date", "?&sort_by=title", "?&sort_by=relevance", "?&ascending=true", "?&descending=true", "&sort_by=date", "&sort_by=title", "&sort_by=relevance", "&ascending=true", "&descending=true", "sort_by=date", "sort_by=title", "sort_by=relevance", "ascending=true", "descending=true"]
+@register.simple_tag
+def search_with_querystring(request, **kwargs):
+    mutable_query_dict = dict(request.GET)
+    mutable_query_dict.update(kwargs)
+    return 'search' + '?' + urllib.parse.urlencode(mutable_query_dict)
 
-    paramsDict = dict((re.escape(el), "") for el in params)
 
-    pattern = re.compile("|".join(paramsDict.keys()))
+@register.simple_tag
+def sort_direction(request):
+    query_dict = request.GET
+    if query_dict.get('sort_by') == 'date':
+        if query_dict.get('asc'):
+            return 'asc'
+        else:
+            return 'desc'
 
-    return pattern.sub(lambda m: paramsDict[re.escape(m.group(0))], url)
-
-# TODO: Clean up for refactor of javascript.
-# @register.simple_tag
-# def query_transform(request, **kwargs):
-
-#     data_dict = dict(request.GET.copy())
-#     print(data_dict)
-#     try:
-#         selected_facet_names = data_dict['selected_facets']
-#     except:
-#         selected_facet_names = []
-
-#     updated = request.GET.copy()
-#     if selected_facet_names:
-#         for k,v in kwargs.items():
-#             selected_facet_names.append(v)
-
-#     updated['selected_facets'] = selected_facet_names
-
-#     return updated.urlencode()
+    if query_dict.get('sort_by') == 'title':
+        if query_dict.get('desc'):
+            return 'desc'
+        else:
+            return 'asc'
 
 
 @register.filter

--- a/councilmatic_core/templatetags/extras.py
+++ b/councilmatic_core/templatetags/extras.py
@@ -7,7 +7,7 @@ from django.utils.safestring import mark_safe
 from django.core.serializers import serialize
 import json
 from django.db.models.query import QuerySet
-from urllib.parse import urlsplit, parse_qs, urlencode
+from urllib.parse import urlsplit, parse_qs, parse_qsl, urlencode
 
 register = template.Library()
 
@@ -129,7 +129,7 @@ def search_with_querystring(request, **kwargs):
     query_as_dict = parse_qs(query)
     query_as_dict.update(kwargs)
    
-    return '/search?' + urlencode(query_as_dict)
+    return '/search?' + urlencode(query_as_dict, doseq=True)
 
 
 @register.simple_tag

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -35,6 +35,7 @@ app_timezone = pytz.timezone(settings.TIME_ZONE)
 class CouncilmaticFacetedSearchView(FacetedSearchView):
 
     def extra_context(self):
+
         # Raise an error if Councilmatic cannot connect to Solr.
         # Most likely, Solr is down and needs restarting.
         try:
@@ -47,9 +48,6 @@ class CouncilmaticFacetedSearchView(FacetedSearchView):
         extra['request'] = self.request
         extra['facets'] = self.results.facet_counts()
 
-        # PROBLEM: self.request.GET does not recognize "order_by" params.
-        # E.g., /search/?sort_by=title&order_by=asc with a query search returns:
-        #  <QueryDict: {'sort_by': ['title'], 'q': ['san pedro']}>
         q_filters = ''
         url_params = [(p, val) for (p, val) in self.request.GET.items(
         ) if p != 'page' and p != 'selected_facets' and p != 'amp' and p != '_']
@@ -59,9 +57,6 @@ class CouncilmaticFacetedSearchView(FacetedSearchView):
             url_params.append(('selected_facets', facet_val))
         if url_params:
             q_filters = urllib.parse.urlencode(url_params)
-
-        # import pdb
-        # pdb.set_trace()
 
         extra['q_filters'] = q_filters
 

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -35,7 +35,6 @@ app_timezone = pytz.timezone(settings.TIME_ZONE)
 class CouncilmaticFacetedSearchView(FacetedSearchView):
 
     def extra_context(self):
-
         # Raise an error if Councilmatic cannot connect to Solr.
         # Most likely, Solr is down and needs restarting.
         try:
@@ -48,6 +47,9 @@ class CouncilmaticFacetedSearchView(FacetedSearchView):
         extra['request'] = self.request
         extra['facets'] = self.results.facet_counts()
 
+        # PROBLEM: self.request.GET does not recognize "order_by" params.
+        # E.g., /search/?sort_by=title&order_by=asc with a query search returns:
+        #  <QueryDict: {'sort_by': ['title'], 'q': ['san pedro']}>
         q_filters = ''
         url_params = [(p, val) for (p, val) in self.request.GET.items(
         ) if p != 'page' and p != 'selected_facets' and p != 'amp' and p != '_']
@@ -57,6 +59,9 @@ class CouncilmaticFacetedSearchView(FacetedSearchView):
             url_params.append(('selected_facets', facet_val))
         if url_params:
             q_filters = urllib.parse.urlencode(url_params)
+
+        # import pdb
+        # pdb.set_trace()
 
         extra['q_filters'] = q_filters
 


### PR DESCRIPTION
This PR addresses a few search-related code smells:
1. it simplifies the template logic for showing sort and order options;
2. it uses the conventions of urllib for url parsing and encoding;
3. it removes the `full_text` from the the Solr index (which contains RTF) and instead uses only the `ocr_full_text`. 

@hancush - requesting your review....but @evz would welcome your feedback, too.

Relates to https://github.com/datamade/la-metro-councilmatic/issues/309