### PR TITLE
Remove commented code, and add input fields for order_by

### DIFF
--- a/councilmatic_core/templates/search/search.html
+++ b/councilmatic_core/templates/search/search.html
@@ -36,6 +36,14 @@
                     <input name="sort_by" type="hidden" class="form-control" value="relevance">
                 {% endif %}
 
+                {% if 'order_by=asc' in request.get_full_path %}
+                    <input name="order_by" type="hidden" class="form-control" value="asc">
+                {% endif %}
+
+                {% if 'order_by=desc' in request.get_full_path %}
+                    <input name="order_by" type="hidden" class="form-control" value="desc">
+                {% endif %}
+
                 {% with formatted_q=request.GET.q|remove_question %}
                     {% include 'partials/search_bar.html' %}
                 {% endwith %}

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -35,7 +35,6 @@ app_timezone = pytz.timezone(settings.TIME_ZONE)
 class CouncilmaticFacetedSearchView(FacetedSearchView):
 
     def extra_context(self):
-
         # Raise an error if Councilmatic cannot connect to Solr.
         # Most likely, Solr is down and needs restarting.
         try:
@@ -49,6 +48,7 @@ class CouncilmaticFacetedSearchView(FacetedSearchView):
         extra['facets'] = self.results.facet_counts()
 
         q_filters = ''
+
         url_params = [(p, val) for (p, val) in self.request.GET.items(
         ) if p != 'page' and p != 'selected_facets' and p != 'amp' and p != '_']
         selected_facet_vals = self.request.GET.getlist('selected_facets')
@@ -105,7 +105,6 @@ class CouncilmaticSearchForm(FacetedSearchForm):
 
     def no_query_found(self):
 
-        # return self.searchqueryset.order_by('-last_action_date').all()
         return self.searchqueryset.all()
 
 # This is used by a context processor in settings.py to render these variables


### PR DESCRIPTION
This fixes a bug in the legislation search, wherein the `order_by` param was not preserved in the query string