### PR TITLE
'nofollow' links to legistar

### DIFF
--- a/councilmatic_core/templates/councilmatic_core/committee.html
+++ b/councilmatic_core/templates/councilmatic_core/committee.html
@@ -23,7 +23,7 @@
                 {% endwith %}
 
                 {% if committee.source_url %}
-                        <a href='{{committee.source_url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank">
+                        <a href='{{committee.source_url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank" rel="nofollow">
                             <i class='fa fa-fw fa-external-link'></i>
                             View on the {{CITY_VOCAB.SOURCE}} website
                         </a>

--- a/councilmatic_core/templates/councilmatic_core/event.html
+++ b/councilmatic_core/templates/councilmatic_core/event.html
@@ -18,7 +18,7 @@
             </p>
 
             <p class="small">
-                <a href='{{event.source_url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank">
+                <a href='{{event.source_url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank" rel="nofollow">
                     <i class='fa fa-fw fa-external-link'></i>
                     View on the {{CITY_VOCAB.SOURCE}} website
                 </a>

--- a/councilmatic_core/templates/councilmatic_core/legislation.html
+++ b/councilmatic_core/templates/councilmatic_core/legislation.html
@@ -38,7 +38,7 @@
                     {% endwith %}
 
                     <!-- Link to legistar -->
-                    <a href='{{legislation.source_url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank">
+                    <a href='{{legislation.source_url}}' title='View on the {{CITY_VOCAB.SOURCE}} website' target="_blank" rel="nofollow">
                         <i class='fa fa-fw fa-external-link'></i> View on the {{CITY_VOCAB.SOURCE}} website
                     </a>
 

--- a/councilmatic_core/templates/councilmatic_core/person.html
+++ b/councilmatic_core/templates/councilmatic_core/person.html
@@ -49,7 +49,7 @@
                 {% endwith %}
 
                 <!-- View on legistar -->
-                <a href='{{person.source_url}}' target="_blank"><i class='fa fa-fw fa-external-link'></i> View on the {{CITY_VOCAB.SOURCE}} website</a>
+                <a href='{{person.source_url}}' target="_blank" rel="nofollow"><i class='fa fa-fw fa-external-link'></i> View on the {{CITY_VOCAB.SOURCE}} website</a>
 
             </div>
 


### PR DESCRIPTION
For many searches we would be the top result if we didn't provide a link to legistar for the search engine spiders. This code uses the [nofollow directive](https://en.wikipedia.org/wiki/Nofollow) to improve our ranking.