### PR TITLE
Customize Highlighter class

### DIFF
--- a/councilmatic_core/static/css/custom.css
+++ b/councilmatic_core/static/css/custom.css
@@ -498,7 +498,7 @@ textarea {
 
 .info-blurb p { font-size: .85em; }
 
-p.search-result em {
+p.search-result em, .highlighted {
     background-color: #D9EDF7;
     font-style: normal;
 }

--- a/councilmatic_core/utils.py
+++ b/councilmatic_core/utils.py
@@ -1,17 +1,18 @@
 from haystack.utils.highlighting import Highlighter
 
-'''
-This class customizes the Haystack Highlighter to allow for 
-highlighting multi-word strings.
-https://django-haystack.readthedocs.io/en/master/highlighting.html#highlighter
-https://github.com/django-haystack/django-haystack/blob/master/haystack/utils/highlighting.py
 
-Use this class to build custom filters in `search_result.html`.
-See LA Metro as a model. 
-'''
 class ExactHighlighter(Highlighter):
+    '''
+    This class customizes the Haystack Highlighter to allow for
+    highlighting multi-word strings.
+    https://django-haystack.readthedocs.io/en/master/highlighting.html#highlighter
+    https://github.com/django-haystack/django-haystack/blob/master/haystack/utils/highlighting.py
+
+    Use this class to build custom filters in `search_result.html`.
+    See LA Metro as a model.
+    '''
     def __init__(self, query, **kwargs):
-        super( Highlighter, self ).__init__()
+        super(Highlighter, self).__init__()
         self.query_words = self.make_query_words(query)
 
     def make_query_words(self, query):
@@ -20,5 +21,5 @@ class ExactHighlighter(Highlighter):
             query_words.add(query.strip('\"'))
         else:
             query_words = set([word.lower() for word in query.split() if not word.startswith("-")])
-        
+
         return query_words

--- a/councilmatic_core/utils.py
+++ b/councilmatic_core/utils.py
@@ -1,0 +1,24 @@
+from haystack.utils.highlighting import Highlighter
+
+'''
+This class customizes the Haystack Highlighter to allow for 
+highlighting multi-word strings.
+https://django-haystack.readthedocs.io/en/master/highlighting.html#highlighter
+https://github.com/django-haystack/django-haystack/blob/master/haystack/utils/highlighting.py
+
+Use this class to build custom filters in `search_result.html`.
+See LA Metro as a model. 
+'''
+class ExactHighlighter(Highlighter):
+    def __init__(self, query, **kwargs):
+        super( Highlighter, self ).__init__()
+        self.query_words = self.make_query_words(query)
+
+    def make_query_words(self, query):
+        query_words = set()
+        if query.startswith('"') and query.endswith('"'):
+            query_words.add(query.strip('\"'))
+        else:
+            query_words = set([word.lower() for word in query.split() if not word.startswith("-")])
+        
+        return query_words


### PR DESCRIPTION
This PR concerns https://github.com/datamade/la-metro-councilmatic/issues/321

[Relevant commit in LA Metro](https://github.com/datamade/la-metro-councilmatic/pull/325/commits/9ac2e902e9268bcf949e54d642147bb32f2722f3)

Important notes:
- we cannot highlight text using Solr, if that text is not "stored" (as opposed to "indexed")
- we do not store the attachment text in the LA Metro Solr index, but we do search it and need to render the results with appropriate highlights 
- Haystack provides a way to do this, but the Highlighter class considers only [one word at a time](https://github.com/django-haystack/django-haystack/blob/master/haystack/utils/highlighting.py#L26) - hence the need for customization.

I placed this class in Councilmatic core, since I imagine we'll need if for future/other Councilmatic instances, [such as NYC](https://github.com/datamade/nyc-council-councilmatic/blob/master/nyc/templates/partials/search_result.html#L16) 

@hancush - for your reference
@evz - for your review