### PR TITLE
Helper function in data_integrity

### DIFF
--- a/councilmatic_core/management/commands/data_integrity.py
+++ b/councilmatic_core/management/commands/data_integrity.py
@@ -16,9 +16,20 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     help = 'Checks for alignment between the Solr index and Councilmatic database'
+    def add_arguments(self, parser):
+        parser.add_argument('--city', 
+                            help='Indicates the name of the custom councilmatic instance.' +
+                                 'Currently supports LAMetroBills.' + 
+                                 'e.g., --city=metro')
 
     def handle(self, *args, **options):
-        councilmatic_count = Bill.objects.all().count()
+        if options['city']:
+            city = options['city']
+            if city == 'metro':
+                from lametro.models import LAMetroBill
+                councilmatic_count = LAMetroBill.objects.all().count()
+        else:
+            councilmatic_count = Bill.objects.all().count()
 
         try:
             solr_url = settings.HAYSTACK_CONNECTIONS['default']['URL']

--- a/councilmatic_core/management/commands/data_integrity.py
+++ b/councilmatic_core/management/commands/data_integrity.py
@@ -16,20 +16,10 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     help = 'Checks for alignment between the Solr index and Councilmatic database'
-    def add_arguments(self, parser):
-        parser.add_argument('--city', 
-                            help='Indicates the name of the custom councilmatic instance.' +
-                                 'Currently supports LAMetroBills.' + 
-                                 'e.g., --city=metro')
 
     def handle(self, *args, **options):
-        if options['city']:
-            city = options['city']
-            if city == 'metro':
-                from lametro.models import LAMetroBill
-                councilmatic_count = LAMetroBill.objects.all().count()
-        else:
-            councilmatic_count = Bill.objects.all().count()
+        
+        councilmatic_count = self.count_councilmatic_bills()
 
         try:
             solr_url = settings.HAYSTACK_CONNECTIONS['default']['URL']
@@ -51,3 +41,7 @@ class Command(BaseCommand):
 
         logger.info('Good news! Solr index has {solr} entites. The Councilmatic database has {councilmatic} entities.'.format(solr=solr_index_count, councilmatic=councilmatic_count))
         print('. . . . .\n')
+
+    def count_councilmatic_bills(self):
+
+        return Bill.objects.all().count()


### PR DESCRIPTION
This PR adds a helper function in the `data_integrity` script. The function returns the number of bills in the Councilmatic database: it can be easily overridden to accommodate bill subclasses [(as with LA Metro).](https://github.com/datamade/la-metro-councilmatic/pull/410/files#diff-38431177dc3e312fcae58da37cffdca3R26)