### PR TITLE
Make update_since an instance attribute

### DIFF
--- a/councilmatic_core/management/commands/import_data.py
+++ b/councilmatic_core/management/commands/import_data.py
@@ -71,7 +71,6 @@ DEBUG = settings.DEBUG
 
 class Command(BaseCommand):
     help = 'loads in data from the open civic data API'
-    update_since = None
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -105,6 +104,8 @@ class Command(BaseCommand):
                             help='Preserve JSON files in downloads directory')
 
     def handle(self, *args, **options):
+        self.update_since = None
+
         self.connection = engine.connect()
 
         self.this_folder = os.path.abspath(os.path.dirname(__file__))

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -5,6 +5,7 @@ django-haystack==2.5.1
 pysolr==3.3.2
 python-dateutil==2.4.2
 django-rq==0.9.1
+rq<1.0
 boto==2.38.0
 boto3==1.9.22
 pytest==3.7.0

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -5,7 +5,6 @@ django-haystack==2.5.1
 pysolr==3.3.2
 python-dateutil==2.4.2
 django-rq==0.9.1
-rq<1.0
 boto==2.38.0
 boto3==1.9.22
 pytest==3.7.0


### PR DESCRIPTION
Attributes defined at the class level should be immutable, as [a whole class of mysterious bugs](https://www.toptal.com/python/python-class-attributes-an-overly-thorough-guide) occurs when a class attribute is changed. 

This PR defines `update_since` in the `handle` method, instead of at the class-level, because we do indeed update it sometimes.