### PR TITLE
Exclude the 'tests' directory from find_packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 setup(
     name='django-councilmatic',
     version='1.0',
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests',)),
     include_package_data=True,
     license='MIT License',  # example license
     description='Core functions for councilmatic.org family',


### PR DESCRIPTION
## Overview

Previously, `find_packages()` didn't [`exclude`](http://code.nabla.net/doc/setuptools/api/setuptools/setuptools.find_packages.html) the tests dir, which would cause pip to install the package under the the name `tests` when installing this . (We introduced this change in v1.0 when we switched from specifying `councilmatic_core` as the package to `find_packages()`).

Exclude the `tests` dir from packaging to prevent `ImportError`s when trying to run tests in dependent packages.

## Testing instructions

Test this change by testing https://github.com/datamade/django-councilmatic-notifications/pull/33:

- `cd` to `django-councilmatic-notifications`
- Install your local version of `django-councilmatic-notifications` (with test dependencies) with `pip install -e .[tests]`
- Install this version of `django-councilmatic`, either by running:

```
pip install /path/to/local/django-councilmatic
```

or 

```
pip install git+https://github.com/datamade/django-councilmatic@feature/jfc/remove-tests-from-find-packages
```

- Run `pytest` and confirm tests run normally