### PR TITLE
Take care to cast dates with empty strings to NULL in model managers

### DIFF
--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -25,20 +25,21 @@ if not hasattr(settings, 'OCD_CITY_COUNCIL_NAME'):
 MANUAL_HEADSHOTS = settings.MANUAL_HEADSHOTS if hasattr(settings, 'MANUAL_HEADSHOTS') else {}
 
 
-def cast_to_datetime(field):
-    """
-    Cast a given field from a CharField to a DateTimeField, converting empty
-    strings to NULL in the process. Useful for CharFields that store timestamps
-    as strings.
-    """
-    return Cast(
-        Case(
-            When(**{field: '', 'then': None}),
-            default=field,
-            output_field=models.CharField()
-        ),
-        models.DateTimeField()
-    )
+class CastToDateTimeMixin:
+    def cast_to_datetime(self, field):
+        """
+        Cast a given field from a CharField to a DateTimeField, converting empty
+        strings to NULL in the process. Useful for CharFields that store timestamps
+        as strings.
+        """
+        return Cast(
+            Case(
+                When(**{field: '', 'then': None}),
+                default=field,
+                output_field=models.CharField()
+            ),
+            models.DateTimeField()
+        )
 
 
 class PersonManager(models.Manager):
@@ -275,18 +276,11 @@ class Post(opencivicdata.core.models.Post):
             return membership
 
 
-class MembershipManager(models.Manager):
+class MembershipManager(models.Manager, CastToDateTimeMixin):
     def get_queryset(self):
-        # Handle null end dates
-        end_date_null = Case(
-            When(end_date='', then=None),
-            default='end_date',
-            output_field=models.CharField()
-        )
-
         return super().get_queryset().annotate(
-            end_date_dt=Cast(end_date_null, models.DateTimeField()),
-            start_date_dt=Cast('start_date', models.DateTimeField())
+            end_date_dt=self.cast_to_datetime('end_date'),
+            start_date_dt=self.cast_to_datetime('start_date')
         )
 
 
@@ -323,11 +317,12 @@ class Membership(opencivicdata.core.models.Membership):
     )
 
 
-class EventManager(models.Manager):
+class EventManager(models.Manager, CastToDateTimeMixin):
     def get_queryset(self):
         return super().get_queryset().annotate(
-            start_time=cast_to_datetime('start_date')
+            start_time=self.cast_to_datetime('start_date')
         )
+
 
 class Event(opencivicdata.legislative.models.Event):
 
@@ -625,10 +620,10 @@ class BillSponsorship(opencivicdata.legislative.models.BillSponsorship):
     person = ProxyForeignKey(Person, null=True, on_delete=models.SET_NULL)
 
 
-class BillActionManager(models.Manager):
+class BillActionManager(models.Manager, CastToDateTimeMixin):
     def get_queryset(self):
         return super().get_queryset().annotate(
-            date_dt=cast_to_datetime('date')
+            date_dt=self.cast_to_datetime('date')
         )
 
 

--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -309,8 +309,16 @@ class Membership(opencivicdata.core.models.Membership):
 
 class EventManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset().annotate(start_time=Cast('start_date',
-                                                               models.DateTimeField()))
+        return super().get_queryset().annotate(
+            start_time=Cast(
+                Case(
+                    When(start_date='', then=None),
+                    default='start_date',
+                    output_field=models.CharField()
+                ),
+                models.DateTimeField()
+            )
+        )
 
 
 class Event(opencivicdata.legislative.models.Event):
@@ -611,8 +619,16 @@ class BillSponsorship(opencivicdata.legislative.models.BillSponsorship):
 
 class BillActionManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset().annotate(date_dt=Cast('date',
-                                                            models.DateTimeField()))
+        return super().get_queryset().annotate(
+            date_dt=Cast(
+                Case(
+                    When(date='', then=None),
+                    default='date',
+                    output_field=models.CharField()
+                ),
+                models.DateTimeField()
+            )
+        )
 
 
 class BillAction(opencivicdata.legislative.models.BillAction):

--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -276,7 +276,7 @@ class Post(opencivicdata.core.models.Post):
             return membership
 
 
-class MembershipManager(models.Manager, CastToDateTimeMixin):
+class MembershipManager(CastToDateTimeMixin, models.Manager):
     def get_queryset(self):
         return super().get_queryset().annotate(
             end_date_dt=self.cast_to_datetime('end_date'),
@@ -317,7 +317,7 @@ class Membership(opencivicdata.core.models.Membership):
     )
 
 
-class EventManager(models.Manager, CastToDateTimeMixin):
+class EventManager(CastToDateTimeMixin, models.Manager):
     def get_queryset(self):
         return super().get_queryset().annotate(
             start_time=self.cast_to_datetime('start_date')
@@ -620,7 +620,7 @@ class BillSponsorship(opencivicdata.legislative.models.BillSponsorship):
     person = ProxyForeignKey(Person, null=True, on_delete=models.SET_NULL)
 
 
-class BillActionManager(models.Manager, CastToDateTimeMixin):
+class BillActionManager(CastToDateTimeMixin, models.Manager):
     def get_queryset(self):
         return super().get_queryset().annotate(
             date_dt=self.cast_to_datetime('date')

--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -25,6 +25,22 @@ if not hasattr(settings, 'OCD_CITY_COUNCIL_NAME'):
 MANUAL_HEADSHOTS = settings.MANUAL_HEADSHOTS if hasattr(settings, 'MANUAL_HEADSHOTS') else {}
 
 
+def cast_to_datetime(field):
+    """
+    Cast a given field from a CharField to a DateTimeField, converting empty
+    strings to NULL in the process. Useful for CharFields that store timestamps
+    as strings.
+    """
+    return Cast(
+        Case(
+            When(**{field: '', 'then': None}),
+            default=field,
+            output_field=models.CharField()
+        ),
+        models.DateTimeField()
+    )
+
+
 class PersonManager(models.Manager):
     def get_queryset(self, *args, **kwargs):
         from django.db.models import Prefetch
@@ -310,16 +326,8 @@ class Membership(opencivicdata.core.models.Membership):
 class EventManager(models.Manager):
     def get_queryset(self):
         return super().get_queryset().annotate(
-            start_time=Cast(
-                Case(
-                    When(start_date='', then=None),
-                    default='start_date',
-                    output_field=models.CharField()
-                ),
-                models.DateTimeField()
-            )
+            start_time=cast_to_datetime('start_date')
         )
-
 
 class Event(opencivicdata.legislative.models.Event):
 
@@ -620,14 +628,7 @@ class BillSponsorship(opencivicdata.legislative.models.BillSponsorship):
 class BillActionManager(models.Manager):
     def get_queryset(self):
         return super().get_queryset().annotate(
-            date_dt=Cast(
-                Case(
-                    When(date='', then=None),
-                    default='date',
-                    output_field=models.CharField()
-                ),
-                models.DateTimeField()
-            )
+            date_dt=cast_to_datetime('date')
         )
 
 


### PR DESCRIPTION
## Summary

While working on https://github.com/datamade/django-councilmatic-notifications/pull/33, I noticed that if OCD `BillActions` or `Events` were saved with date values corresponding to empty strings, their date attributes would fail to be properly cast to `DateTimeFields`:

```
(councilmatic_models.BillAction.objects.annotate(test=Cast('date', models.DateTimeField()))
*** django.db.utils.DataError: invalid input syntax for type timestamp with time zone: ""
```

This PR adjusts the model managers implicated in `django-councilmatic-notifications` to appropriately cast empty strings to `NULL`.

## Notes

@hancush [pointed out](https://github.com/datamade/django-councilmatic-notifications/pull/33#discussion_r302754377) that all of the date-related model attributes probably need to be handled in this way. That's a good point, but I'm not sure whether or not we should do it as part of this work. Since I don't have a good grasp of how pervasive this problem might be, I leave that decision up to others.

## Testing instructions

I added tests to https://github.com/datamade/django-councilmatic-notifications/pull/33 using these new null managers, so install this branch of `django-councilmatic` and run those tests to confirm tha they work.