### PR TITLE
Add local_start_time property to Event model

### DIFF
--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -374,6 +374,10 @@ class Event(opencivicdata.legislative.models.Event):
                   .exclude(name__icontains=settings.CITY_COUNCIL_MEETING_NAME)\
                   .order_by('start_time').all()[:3]
 
+    @property
+    def local_start_time(self):
+        return timezone.localtime(self.start_time)
+
 
 class Bill(opencivicdata.legislative.models.Bill):
 

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -432,7 +432,7 @@ class EventsView(ListView):
 
         # Did the user set date boundaries?
         date_str = self.request.GET.get('form_datetime')
-        day_grouper = lambda x: x.start_time.date
+        day_grouper = lambda x: x.local_start_time.date
         context['select_date'] = ''
 
         # If yes, then filter for dates.


### PR DESCRIPTION
## Description

The start time we generate is in UTC. This is fine most places, but we group events for display by date using the year, month, and day from that UTC time. Again, this is fine most of the time, unless an event is scheduled for a time translates to after midnight in UTC, causing the event to be grouped with the following day for display. This PR adds a local start time property to the Event model and uses it to group events for display.