### PR TITLE
Refresh bill *versions*, as well as bill documents

### DIFF
--- a/councilmatic_core/management/commands/refresh_pic.py
+++ b/councilmatic_core/management/commands/refresh_pic.py
@@ -10,8 +10,8 @@ from django.conf import settings
 from django.db.models import Q
 import pytz
 
-from opencivicdata.legislative.models import BillDocumentLink, EventDocumentLink, \
-    EventRelatedEntity
+from opencivicdata.legislative.models import BillDocumentLink, BillVersionLink, \
+    EventDocumentLink, EventRelatedEntity
 
 
 for configuration in ['AWS_KEY','AWS_SECRET']:
@@ -19,8 +19,11 @@ for configuration in ['AWS_KEY','AWS_SECRET']:
         raise ImproperlyConfigured(
             'Please define {0} in settings_deployment.py'.format(configuration))
 
+
 logging.config.dictConfig(settings.LOGGING)
 logger = logging.getLogger(__name__)
+
+app_timezone = pytz.timezone(settings.TIME_ZONE)
 
 
 class Command(BaseCommand):
@@ -31,16 +34,63 @@ class Command(BaseCommand):
         from boto.s3.key import Key
         from boto.exception import S3ResponseError
 
-        document_urls = self._get_urls()
-        aws_keys = self._create_keys(document_urls)
-
         s3_conn = S3Connection(settings.AWS_KEY, settings.AWS_SECRET)
 
+        document_urls = self._get_urls()
+        aws_keys = self._create_keys(document_urls)
         bucket = s3_conn.get_bucket('councilmatic-document-cache')
-
         bucket.delete_keys(aws_keys)
 
         logger.info(("Removed {} document(s) from the councilmatic-document-cache").format(len(aws_keys)))
+
+    @property
+    def local_now(self):
+        return app_timezone.localize(datetime.datetime.now())
+
+    @property
+    def bills_on_upcoming_agendas(self):
+        if not hasattr(self, '_bills_on_upcoming_agendas'):
+            self._bills_on_upcoming_agendas = EventRelatedEntity.objects.filter(
+                bill__isnull=False,
+                agenda_item__event__start_date__gte=self.local_now
+            ).values_list('bill__id')
+        return self._bills_on_upcoming_agendas
+
+    def _get_bill_versions(self, window_start):
+        '''
+        Retrieve URLs of updated and upcoming versions, i.e., the bills
+        themselves.
+        '''
+        recently_updated = Q(version__bill__updated_at__gte=window_start)
+        upcoming = Q(version__bill__id__in=self.bills_on_upcoming_agendas)
+
+        return BillVersionLink.objects.filter(
+            recently_updated | upcoming
+        ).values_list('url', flat=True)
+
+    def _get_bill_documents(self, window_start):
+        '''
+        Retrieve URLs of updated and upcoming documents, i.e., attachments
+        to bills (versions).
+        '''
+        has_versions = Q(document__bill__versions__isnull=False)
+        recently_updated = Q(document__bill__updated_at__gte=window_start)
+        upcoming = Q(document__bill__id__in=self.bills_on_upcoming_agendas)
+
+        return BillDocumentLink.objects.filter(
+            has_versions & (recently_updated | upcoming)
+        ).values_list('url', flat=True)
+
+    def _get_event_documents(self, window_start):
+        '''
+        Retrieve URLs of updated and upcoming event documents, i.e., agendas.
+        '''
+        recently_updated = Q(document__event__updated_at__gte=window_start)
+        upcoming = Q(document__event__start_date__gte=self.local_now)
+
+        return EventDocumentLink.objects.filter(
+            recently_updated | upcoming
+        ).values_list('url', flat=True)
 
     def _get_urls(self):
         '''
@@ -54,29 +104,13 @@ class Command(BaseCommand):
         that tell us to rescrape entities, toggling the updated timestamps in
         our database.
         '''
-        app_timezone = pytz.timezone(settings.TIME_ZONE)
         one_hour_ago = app_timezone.localize(datetime.datetime.now()) - datetime.timedelta(hours=1)
 
-        has_versions = Q(document__bill__versions__isnull=False)
-
-        recently_updated = Q(document__bill__updated_at__gte=one_hour_ago)
-
-        bills_on_upcoming_agendas = EventRelatedEntity.objects.filter(
-            bill__isnull=False,
-            agenda_item__event__start_date__gt=one_hour_ago
-        ).values_list('bill__id')
-
-        upcoming = Q(document__bill__id__in=bills_on_upcoming_agendas)
-
-        bill_docs = BillDocumentLink.objects.filter(
-            has_versions & (recently_updated | upcoming)
-        ).values_list('url', flat=True)
-
-        event_docs = EventDocumentLink.objects.filter(
-            Q(document__event__updated_at__gte=one_hour_ago) | Q(document__event__start_date__gt=one_hour_ago)
-        ).values_list('url', flat=True)
-
-        return itertools.chain(bill_docs, event_docs)
+        return itertools.chain(
+            self._get_bill_versions(one_hour_ago),
+            self._get_bill_documents(one_hour_ago),
+            self._get_event_documents(one_hour_ago)
+        )
 
     def _create_keys(self, document_urls):
         return [urllib.parse.quote_plus(url) for url in document_urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,8 @@ from django.db import connection
 from councilmatic_core.models import Bill, Event
 from opencivicdata.core.models import Jurisdiction, Division
 from opencivicdata.legislative.models import BillDocumentLink, EventDocument, \
-    EventDocumentLink, LegislativeSession, BillVersion, BillDocument
+    EventDocumentLink, LegislativeSession, BillVersion, BillDocument, \
+    BillVersionLink
 
 
 @pytest.fixture
@@ -90,7 +91,7 @@ def ocd_bill_document(metro_bill, transactional_db):
     document = BillDocument.objects.create(**document_info)
 
     document_link_info = {
-        'url': 'https://metro.legistar.com/ViewReport.ashx?M=R&N=TextL5&GID=557&ID=5016&GUID=LATEST&Title=Board+Report.pdf',
+        'url': 'http://metro.legistar1.com/metro/attachments/e041786b-a42a-4d03-bd3e-06d5b3113de2.pdf',
         'document': document,
     }
 
@@ -99,6 +100,11 @@ def ocd_bill_document(metro_bill, transactional_db):
     version = BillVersion.objects.create(bill=metro_bill,
                                          note='test',
                                          date='1992-02-16')
+
+    BillVersionLink.objects.create(
+        version=version,
+        url='https://metro.legistar.com/ViewReport.ashx?M=R&N=TextL5&GID=557&ID=5016&GUID=LATEST&Title=Board+Report.pdf'
+    )
 
     metro_bill.versions.add(version)
     metro_bill.save()

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -8,18 +8,25 @@ from councilmatic_core.management.commands.convert_attachment_text import Comman
 def test_refresh_pic(ocd_bill_document,
                      metro_event_document):
     '''
-    Test that the `_get_urls` and `_create_keys` successfully finds changed bill and event documents
-    and converts their urls to a list of AWS keys.
+    Test that the `_get_urls` and `_create_keys` successfully finds changed
+    bill and event documents and converts their urls to a list of AWS keys.
     '''
     command = RefreshPic()
     document_urls = list(command._get_urls())
 
+    # Test that each of the URLs we expect exist, and that no other URLs
+    # exist.
+    bill_version_link, = ocd_bill_document.bill.versions.get().links.all()
     bill_doc_link, = ocd_bill_document.links.all()
     event_doc_link, = metro_event_document.links.all()
 
-    assert (bill_doc_link.url in document_urls) == True
-    assert (event_doc_link.url in document_urls) == True
+    assert len(document_urls) == 3
 
+    assert bill_version_link.url in document_urls
+    assert bill_doc_link.url in document_urls
+    assert event_doc_link.url in document_urls
+
+    # Test that creating keys from URLs yields the correct number of keys.
     aws_keys = command._create_keys(document_urls)
 
     assert len(document_urls) == len(aws_keys)


### PR DESCRIPTION
## Description

This PR reorganizes the `refresh_pic` management command and adds a method to retrieve bill versions, as well as bill documents, for cache refresh. This handles a bug where updating the bill itself did not trigger a cache refresh, since that resource is stored as a `BillVersion`, not a `BillDocument`. More: https://github.com/datamade/la-metro-councilmatic/issues/621

## Testing instructions

- The tests have been updated to cover this case.
- I also shelled into the production server and confirm that this logic would have captured the bill that was not updated:

```python
>>> import datetime

>>> from django.conf import settings
>>> from opencivicdata.legislative.models import *
>>> from pytz import timezone

>>> from lametro.models import LAMetroBill

>>> app_timezone = pytz.timezone(settings.TIME_ZONE)
>>> june_17 = app_timezone.localize(datetime.datetime(2020, 6, 17))
>>> bills_on_upcoming_agendas = EventRelatedEntity.objects.filter(bill__isnull=False, agenda_item__event__start_date__gt=june_17).filter(bill__identifier='2020-0414')
>>> bills_on_upcoming_agendas
<QuerySet [<EventRelatedEntity: 2020-0414 related to Agenda item 21 for Executive Management Committee (2020-06-18T18:30:00+00:00)>, <EventRelatedEntity: 2020-0414 related to Agenda item 40 for Regular Board Meeting (2020-06-25T17:00:00+00:00)>]>

>>> upcoming = bills_on_upcoming_agendas.values_list('bill_id')
>>> BillVersionLink.objects.filter(version__bill__id__in=upcoming)
<QuerySet [<BillVersionLink: https://metro.legistar.com/ViewReport.ashx?M=R&N=TextL5&GID=557&ID=6856&GUID=LATEST&Title=Board+Report for  version of 2020-0414 in Los Angeles County Metropolitan Transportation Authority >]>
```