### PR TITLE
Properly escape selected facets in search.html

### DIFF
--- a/councilmatic_core/templates/search/search.html
+++ b/councilmatic_core/templates/search/search.html
@@ -275,6 +275,7 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ selected_facets|json_script:"selected-facets" }}
     <script>
     $(document).ready(function() {
         $("#searchSubscribe").click(function() {
@@ -283,7 +284,7 @@
 
             if ('{{ request.user }}' != 'AnonymousUser') {
                 posturl2 = "/search_check_subscription/"
-                facets2 = JSON.stringify({{selected_facets|safe}});
+                facets2 = $('#selected-facets').text();
                 stuff2 = $.post(posturl2, { query: "{{request.GET.q}}", selected_facets: facets2 },
                     function(data, status) {
                     console.log("returned from post with data: ", data, "status:", status);
@@ -291,7 +292,7 @@
                 console.log("Could not check subscription for interest {{request.GET.q}} with {{facets2}}" );
                 }),
                 posturl = "/search_subscribe/" //+ "{{request.GET.q}}"
-                facets =  JSON.stringify({{selected_facets|safe}});
+                facets =  $('#selected-facets').text();
                 $.post(posturl, { query: "{{request.GET.q}}", selected_facets: facets }).then(function() {
                     $(bullHorn).hide();
                     $(bullHornNew).show();

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
                       'opencivicdata>=3.1.0',
                       'pytz>=2015.4',
                       'django-haystack>=2.8.0,<2.9',
-                      'Django>=2.0,<2.2',
+                      'Django>=2.1,<2.2',
                       'django-proxy-overrides>=0.2.1',
                       'python-dateutil>=2.7,<2.8',
                       'pysolr>=3.8,<3.9',


### PR DESCRIPTION
## Overview

This PR udpates `search/search.html` to properly escape selected facets using [`json_script`](https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#json-script).

Connects #270 

## Notes

This PR only fixes the bug in Councilmatic 2.5. Councilmatic 1.0 will have to be fixed separately.

## Testing instructions

* Follow the testing instructions here: https://github.com/datamade/la-metro-councilmatic/pull/643
