### PR TITLE
silently swallow a couple errors instead of crashing the site.

### DIFF
--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -228,6 +228,10 @@ class Organization(opencivicdata.core.models.Organization, CastToDateTimeMixin):
                 .select_related("person__councilmatic_person")
             )
             for chair in chairs:
+                if chair.person is None:
+                    # Silently continue if a None person was added in scraping, 
+                    # instead of crashing the site.
+                    continue
                 chair.person = chair.person.councilmatic_person
             return chairs
         else:
@@ -305,7 +309,10 @@ class Post(opencivicdata.core.models.Post):
             .select_related("person__councilmatic_person")
             .first()
         )
-        if membership:
+        if membership and membership.person:
+            # Added `and membership.person` to silently
+            # handle the situation where a None membership gets added.
+            # And return nothing, instead of crashing the app.
             membership.person = membership.person.councilmatic_person
             return membership
 

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -320,7 +320,6 @@ class CommitteeDetailView(DetailView):
                 for ces in user.committeeeventsubscriptions.all():
                     if committee == ces.committee:
                         context["user_subscribed_events"] = True
-
         return context
 
 


### PR DESCRIPTION
Silently swallow a couple of errors if data were incorrectly scraped. There's nothing to show, so lets show the user nothing instead of crashing the site.

I don't know if this is helpful, but in case it is, these were useful tweaks for me. I found it more convenient to have the site show what data it has, instead of crashing on an unexpectedly missing value.