### PR TITLE
Make headshot backend configurable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     services:
       postgres:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
 
   # Black config (Python formatter)
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.4.2
     hooks:
       - id: black
         exclude: ^(councilmatic_core/migrations/)

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ The django-councilmatic app provides the core functionality for the `Councilmati
 
 Requirements
 ------------
-- Python >= 3.6
+- Python >= 3.8
 
 Features
 --------

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,13 @@
 # Release notes for django-councilmatic
 
+## Version 3.3
+
+_Changes_
+
+Allows storage backend for Person headshots to be configured via `COUNCILMATIC_HEADSHOT_STORAGE_BACKEND` setting.
+
+**Release date:** 07-15-2024
+
 ## Version 3.2
 
 _Changes_

--- a/councilmatic_core/feeds.py
+++ b/councilmatic_core/feeds.py
@@ -262,7 +262,6 @@ class EventsFeed(Feed):
 
     title = settings.CITY_COUNCIL_NAME + " " + "Recent Events"
     link = reverse_lazy("events")
-    description = "Recently announced events."
 
     def item_link(self, event):
         # return the Councilmatic URL for the event
@@ -272,7 +271,7 @@ class EventsFeed(Feed):
         return event.start_time
 
     def description(self, obj):
-        return "Events"
+        return "Recently Announced Events"
 
     def items(self, obj):
         return Event.objects.all()[: self.NUM_RECENT_EVENTS]

--- a/councilmatic_core/models.py
+++ b/councilmatic_core/models.py
@@ -16,13 +16,12 @@ from proxy_overrides.related import ProxyForeignKey
 import opencivicdata.legislative.models
 import opencivicdata.core.models
 
-
 static_storage = FileSystemStorage(
     location=os.path.join(settings.STATIC_ROOT), base_url="/"
 )
 
-MANUAL_HEADSHOTS = (
-    settings.MANUAL_HEADSHOTS if hasattr(settings, "MANUAL_HEADSHOTS") else {}
+HEADSHOT_STORAGE_BACKEND = getattr(
+    settings, "COUNCILMATIC_HEADSHOT_STORAGE_BACKEND", static_storage
 )
 
 
@@ -62,7 +61,7 @@ class Person(opencivicdata.core.models.Person):
 
     headshot = models.FileField(
         upload_to="images/headshots",
-        storage=static_storage,
+        storage=HEADSHOT_STORAGE_BACKEND,
         default="images/headshot_placeholder.png",
     )
 
@@ -352,7 +351,7 @@ class Membership(opencivicdata.core.models.Membership, CastToDateTimeMixin):
         null=True,
         # Membership will just unlink if the post goes away
         on_delete=models.SET_NULL,
-        help_text="	The Post held by the member in the Organization.",
+        help_text=" The Post held by the member in the Organization.",
     )
 
 

--- a/councilmatic_core/views.py
+++ b/councilmatic_core/views.py
@@ -366,13 +366,14 @@ class PersonDetailView(DetailView):
         seo.update(settings.SITE_META)
         if person.current_council_seat:
             short_name = re.sub(r",.*", "", person.name)
-            seo[
-                "site_desc"
-            ] = "%s - %s representative in %s. See what %s has been up to!" % (
-                person.name,
-                person.current_council_seat,
-                settings.CITY_COUNCIL_NAME,
-                short_name,
+            seo["site_desc"] = (
+                "%s - %s representative in %s. See what %s has been up to!"
+                % (
+                    person.name,
+                    person.current_council_seat,
+                    settings.CITY_COUNCIL_NAME,
+                    short_name,
+                )
             )
         else:
             seo["site_desc"] = "Details on %s, %s" % (

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,4 @@ DJANGO_SETTINGS_MODULE = tests.test_config
 django_find_project = false
 testpaths = tests
 addopts = -sxv
-pythonpath = . src
+pythonpath = .

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ DJANGO_SETTINGS_MODULE = tests.test_config
 django_find_project = false
 testpaths = tests
 addopts = -sxv
+pythonpath = . src

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email="info@datamade.us",
     install_requires=[
         "requests>=2.20",
-        "opencivicdata>=3.1.0,<=3.2.0",
+        "opencivicdata>=3.1.0",
         "pytz>=2015.4",
         "django-haystack>=3.2,<3.3",
         "Django>=3.2,<3.3",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email="info@datamade.us",
     install_requires=[
         "requests>=2.20",
-        "opencivicdata>=3.1.0",
+        "opencivicdata>=3.1.0,<=3.2.0",
         "pytz>=2015.4",
         "django-haystack>=3.2,<3.3",
         "Django>=3.2,<3.3",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 setup(
     name="django-councilmatic",
     python_requires=">=3.6",
-    version="3.2",
+    version="3.3",
     packages=find_packages(exclude=("tests",)),
     include_package_data=True,
     license="MIT License",  # example license


### PR DESCRIPTION
## Description

This PR allows the headshot file storage backend to be configured by downstream instances via the `COUNCILMATIC_HEADSHOT_STORAGE_BACKEND` setting. It defaults to static storage, its original value.

### Testing

See https://github.com/Metro-Records/la-metro-councilmatic/pull/1134