### PR TITLE
Escape Solr-special chars and colons in RSS facet values

### DIFF
--- a/councilmatic_core/feeds.py
+++ b/councilmatic_core/feeds.py
@@ -29,6 +29,19 @@ class CouncilmaticFacetedSearchFeed(Feed):
     def url_with_querystring(self, path, **kwargs):
         return path + "?" + urllib.parse.urlencode(kwargs)
 
+    @staticmethod
+    def _narrow_facet(results, facet):
+        # Split on the first ":" only so facet values that contain a colon
+        # (#262) don't blow up with "too many values to unpack".
+        facet_name, sep, facet_value = facet.partition(":")
+        if not sep:
+            return results
+        facet_name = facet_name.rsplit("_exact")[0]
+        # Quote the value so Solr-meaningful characters inside it (slashes,
+        # parentheses, colons, etc., per #276) aren't parsed as query syntax.
+        escaped = facet_value.replace("\\", "\\\\").replace('"', '\\"')
+        return results.narrow('%s:"%s"' % (facet_name, escaped))
+
     def get_object(self, request):
         self.queryDict = request.GET
 
@@ -44,14 +57,11 @@ class CouncilmaticFacetedSearchFeed(Feed):
 
             if facets:
                 for facet in facets:
-                    (facet_name, facet_value) = facet.split(":")
-                    facet_name = facet_name.rsplit("_exact")[0]
-                    results = results.narrow("%s:%s" % (facet_name, facet_value))
+                    results = self._narrow_facet(results, facet)
         elif facets:
+            results = all_results
             for facet in facets:
-                (facet_name, facet_value) = facet.split(":")
-                facet_name = facet_name.rsplit("_exact")[0]
-                results = all_results.narrow("%s:%s" % (facet_name, facet_value))
+                results = self._narrow_facet(results, facet)
 
         return results.order_by("-last_action_date")
 


### PR DESCRIPTION
Two related bugs in `CouncilmaticFacetedSearchFeed.get_object`:

* `facet.split(':')` insists on exactly two pieces, so a facet value that contains a colon (an OCD ID, a value with a time, etc.) crashes with `ValueError: too many values to unpack`. Switch to `partition(':')` so any extra colons stay in the value. Closes #262.
* The facet value gets concatenated into the Solr query unquoted, so values that contain `/`, `(`, `)`, etc. (`Federal Legislation / State Legislation (Position)` is the example from #276) come back as Solr syntax errors. Quote the value and escape inner backslashes / quotes. Closes #276.

Pulled the per-facet logic out into a small `_narrow_facet` helper since both branches now do the same thing.

While I was in there, the no-query `elif` branch was doing `results = all_results.narrow(facet)` inside the loop, which drops every narrow except the last. Switched it to chain on the accumulating `results` like the with-query branch already does. Happy to split that out if you'd rather keep the PR scoped.